### PR TITLE
DTSPO-31007 - update to use new agent pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ resources:
 extends:
   template: pipelines/terratest.yaml@cppAzureDevOpsTemplates
   parameters:
-    agentPool: "MDV-ADO-AGENTS-01"
+    agentPool: "ubuntu-ado-agents-mdv"
     azureServiceConnection: "ado_nonlive_workload_identity"
     terratestTimeout: "30"
     tfversion: 1.14.3


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31007

### Change description

- Update ADO agent from legacy Cent OS to new ADO Ubuntu 24.04 version.

### Testing done

- Pipeline passes ok
- Entire terratest lifecycle now working correctly on the new ubuntu-ado-agents-mdv pool - create → test → destroy

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
